### PR TITLE
add local wallets to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__
 .mypy_cache
 *~
+wallet-*.txt


### PR DESCRIPTION
When a wallet's keys are saved locally, there is a file created locally in the repo called `wallet-{some uuid}.txt`.

This will ignore that file and any like it as to not include wallet keys in the repo